### PR TITLE
feat: added /emergency endpoint

### DIFF
--- a/roverd/openapi/README.md
+++ b/roverd/openapi/README.md
@@ -12,7 +12,7 @@ server, you can easily generate a server stub.
 To see how to make this your own, look here: [README]((https://openapi-generator.tech))
 
 - API version: 1.0.0
-- Build date: 2025-02-25T17:51:35.646174010Z[GMT]
+- Build date: 2025-03-03T14:40:39.022896948Z[GMT]
 - Generator version: 7.10.0
 
 

--- a/roverd/openapi/src/apis/health.rs
+++ b/roverd/openapi/src/apis/health.rs
@@ -10,6 +10,18 @@ use crate::{models, types::*};
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[must_use]
 #[allow(clippy::large_enum_variant)]
+pub enum EmergencyPostResponse {
+    /// Operation was successful
+    Status200_OperationWasSuccessful,
+    /// Error occurred
+    Status400_ErrorOccurred(models::RoverdError),
+    /// Unauthorized Access
+    Status401_UnauthorizedAccess,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[must_use]
+#[allow(clippy::large_enum_variant)]
 pub enum RootGetResponse {
     /// The health and versioning information
     Status200_TheHealthAndVersioningInformation(models::Get200Response),
@@ -55,6 +67,16 @@ pub enum UpdatePostResponse {
 #[async_trait]
 #[allow(clippy::ptr_arg)]
 pub trait Health {
+    /// Stops any running pipeline and emergency stops the rover..
+    ///
+    /// EmergencyPost - POST /emergency
+    async fn emergency_post(
+        &self,
+        method: Method,
+        host: Host,
+        cookies: CookieJar,
+    ) -> Result<EmergencyPostResponse, ()>;
+
     /// Retrieve the health and versioning information.
     ///
     /// RootGet - GET /

--- a/roverd/roverd/src/apis/health.rs
+++ b/roverd/roverd/src/apis/health.rs
@@ -152,4 +152,22 @@ impl Health for Roverd {
             rover_is_operating!(ShutdownPostResponse)
         }
     }
+
+    /// Shutdown the rover..
+    /// `RoverState` - This function can run *only when dormant*
+    /// TODO: fs_lock
+    /// ShutdownPost - POST /shutdown
+    async fn emergency_post(
+        &self,
+        _method: Method,
+        _host: Host,
+        _cookies: CookieJar,
+    ) -> Result<EmergencyPostResponse, ()> {
+        if let Some(rover_state) = self.try_get_operating().await {
+            let _ = warn_generic!(self.app.stop(rover_state).await, EmergencyPostResponse);
+        }
+
+        warn_generic!(self.app.emergency_stop_rover().await, EmergencyPostResponse);
+        Ok(EmergencyPostResponse::Status200_OperationWasSuccessful)
+    }
 }

--- a/roverd/roverd/src/app/mod.rs
+++ b/roverd/roverd/src/app/mod.rs
@@ -876,6 +876,17 @@ impl App {
         Ok(())
     }
 
+    /// Spawns a process to emergency stop the rover
+    pub async fn emergency_stop_rover(&self) -> Result<(), Error> {
+        let mut emergency = Command::new("/home/debix/ase/bin/rover-reset");
+
+        match emergency.spawn() {
+            Ok(_) => (),
+            Err(e) => error!("unable to run emergency command: {}", e),
+        }
+        Ok(())
+    }
+
     pub async fn get_fqns(&self) -> Result<Vec<FullyQualifiedService>, Error> {
         let mut fqns = Vec::new();
         let rover_dir = Path::new(ROVER_DIR);

--- a/spec/api/schema.yaml
+++ b/spec/api/schema.yaml
@@ -770,6 +770,19 @@ paths:
         "401":
           $ref: "#/components/responses/UnauthorizedError"
 
+  /emergency:
+    post:
+      tags:
+        - "Health"
+      summary: "Stops any running pipeline and emergency stops the rover."
+      responses:
+        "200":
+          $ref: "#/components/responses/Success"
+        "400":
+          $ref: "#/components/responses/Error"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+
 # Set global security requirement
 security:
   - BasicAuth: []


### PR DESCRIPTION
@ielaajezdev 

Finally added a correct implementation of rover-reset to the the ansible setup. Though it could be nice to add a /emergency endpoint which will stop the pipeline if there is one running and then run the rover-reset command.

