### PR TITLE
fix: using mv instead of os.Rename

### DIFF
--- a/roverctl/src/commands/service_init/services.go
+++ b/roverctl/src/commands/service_init/services.go
@@ -124,9 +124,11 @@ func downloadTemplate(repository string, destination string) error {
 		return fmt.Errorf("Could not remove .git folder: %v", err)
 	}
 
-	// Move the template to the destination
-	err = os.Rename(tmp, destination)
-	if err != nil {
+	// Move the template to the destination. Using linux 'mv' command because Go's os.Rename requires
+	// src and dest to be part of the same mount point, which in some cases is not always true.
+	// Testing showed that using os.Rename on some systems would yield "invalid cross-device link" error.
+	cmd := exec.Command("mv", tmp, destination)
+	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("Could not move template: %v", err)
 	}
 


### PR DESCRIPTION
On my system I got an error bc /tmp is on another mountpoint for me. After some digging it seems that renaming / copying is not so trivial in Go (https://stackoverflow.com/questions/51779243/copy-a-folder-in-go#56314145)