### PR TITLE
Crud commands and UI improvements

### DIFF
--- a/roverctl/install.sh
+++ b/roverctl/install.sh
@@ -87,4 +87,12 @@ if ! command -v roverctl &> /dev/null; then
   echo "Added ${INSTALL_DIR} to PATH in $shell_profile. Please restart your shell or run 'source $shell_profile'."
 fi
 
+# Add alias for rover
+shell_profile=$(detect_shell_profile)
+if ! grep -q "alias rover=" "$shell_profile"; then
+  echo "Adding alias 'rover' for 'roverctl'..."
+  echo "alias rover='roverctl'" >> "$shell_profile"
+  echo "Alias added to $shell_profile. Please restart your shell or run 'source $shell_profile'."
+fi
+
 echo "Installation complete! Run 'roverctl' to get started."

--- a/roverctl/src/commands/author/author.go
+++ b/roverctl/src/commands/author/author.go
@@ -18,9 +18,9 @@ func Add(rootCmd *cobra.Command) {
 
 	// info command
 	var infoCmd = &cobra.Command{
-		Use:   "author",
-		Short: "Set the author name used for service uploads",
-		Long:  `Set the author name used for service uploads`,
+		Use:     "author",
+		Aliases: []string{"a"},
+		Short:   "Set the author name used for service uploads",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			s := state.Get()
 			if s == nil {

--- a/roverctl/src/commands/calibrate/calibrate.go
+++ b/roverctl/src/commands/calibrate/calibrate.go
@@ -33,8 +33,9 @@ func Add(rootCmd *cobra.Command) {
 
 	// pipeline command
 	var infoCmd = &cobra.Command{
-		Use:   "calibrate",
-		Short: "Calibrate an actuator service",
+		Use:     "calibrate",
+		Aliases: []string{"cal", "c", "ca", "cali", "trim"},
+		Short:   "Calibrate an actuator service",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			conn, er := command_prechecks.Perform(cmd, args, roverIndex, roverdHost, roverdUsername, roverdPassword)
 			if er != nil {

--- a/roverctl/src/commands/info/info.go
+++ b/roverctl/src/commands/info/info.go
@@ -18,9 +18,10 @@ func Add(rootCmd *cobra.Command) {
 
 	// info command
 	var infoCmd = &cobra.Command{
-		Use:   "info",
-		Short: "View roverctl and roverd information",
-		Long:  `Display build and connection information for roverctl, and roverd if a rover is specified.`,
+		Use:     "info",
+		Aliases: []string{"i", "version", "about", "v"},
+		Short:   "View roverctl and roverd information",
+		Long:    `Display build and connection information for roverctl, and roverd if a rover is specified.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Ignore errors
 			conn, _ := command_prechecks.Perform(cmd, args, roverIndex, roverdHost, roverdUsername, roverdPassword)

--- a/roverctl/src/commands/logs/logs.go
+++ b/roverctl/src/commands/logs/logs.go
@@ -22,9 +22,10 @@ func Add(rootCmd *cobra.Command) {
 
 	// logs command
 	var infoCmd = &cobra.Command{
-		Use:   "logs <author> <name> <version>",
-		Short: "View logs for a fully qualified service",
-		Long:  `View a specified number of log lines from a service fully qualified by its author, name and version`,
+		Use:     "logs <author> <name> <version>",
+		Aliases: []string{"log", "l"},
+		Short:   "View logs for a fully qualified service",
+		Long:    `View a specified number of log lines from a service fully qualified by its author, name and version`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 3 {
 				return fmt.Errorf("exactly one fully qualified service must be provided in the form <author> <name> <version>")

--- a/roverctl/src/commands/pipeline/disable.go
+++ b/roverctl/src/commands/pipeline/disable.go
@@ -21,8 +21,9 @@ func addDisable(rootCmd *cobra.Command) {
 
 	// pipeline command
 	var infoCmd = &cobra.Command{
-		Use:   "disable <author> <name> [<version>]",
-		Short: "Disable a service in the pipeline",
+		Use:     "disable <author> <name> [<version>]",
+		Aliases: []string{"d"},
+		Short:   "Disable a service in the pipeline",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 2 {
 				return fmt.Errorf("exactly one fully qualified service must be provided in the form <author> <name> [<version>]")

--- a/roverctl/src/commands/pipeline/enable.go
+++ b/roverctl/src/commands/pipeline/enable.go
@@ -21,8 +21,9 @@ func addEnable(rootCmd *cobra.Command) {
 
 	// pipeline command
 	var infoCmd = &cobra.Command{
-		Use:   "enable <author> <name> <version>",
-		Short: "Enable a service in the pipeline",
+		Use:     "enable <author> <name> <version>",
+		Aliases: []string{"e"},
+		Short:   "Enable a service in the pipeline",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 3 {
 				return fmt.Errorf("exactly one fully qualified service must be provided in the form <author> <name> <version>")

--- a/roverctl/src/commands/pipeline/pipeline.go
+++ b/roverctl/src/commands/pipeline/pipeline.go
@@ -21,8 +21,9 @@ func Add(rootCmd *cobra.Command) {
 
 	// pipeline command
 	var infoCmd = &cobra.Command{
-		Use:   "pipeline",
-		Short: "Get the currently active pipeline",
+		Use:     "pipeline",
+		Aliases: []string{"pipe", "p", "pi", "pl"},
+		Short:   "Get the currently active pipeline",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			conn, er := command_prechecks.Perform(cmd, args, roverIndex, roverdHost, roverdUsername, roverdPassword)
 			if er != nil {

--- a/roverctl/src/commands/pipeline/pipeline.go
+++ b/roverctl/src/commands/pipeline/pipeline.go
@@ -3,6 +3,7 @@ package command_pipeline
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -52,6 +53,10 @@ func Add(rootCmd *cobra.Command) {
 			fmt.Printf("Pipeline status: %s\n", statusStr)
 			for _, enabled := range res.Enabled {
 				fmt.Println("- " + enabled.Service.Fq.Author + "/" + enabled.Service.Fq.Name + " (" + enabled.Service.Fq.Version + ")")
+			}
+
+			if res.Status == openapi.STARTED {
+				fmt.Printf("Pipeline has been running since %s\n", style.Primary.Render(time.Unix(*res.LastStart/1000, 0).String()))
 			}
 
 			return nil

--- a/roverctl/src/commands/pipeline/reset.go
+++ b/roverctl/src/commands/pipeline/reset.go
@@ -20,8 +20,9 @@ func addReset(rootCmd *cobra.Command) {
 
 	// pipeline command
 	var infoCmd = &cobra.Command{
-		Use:   "reset",
-		Short: "Reset the currently active pipeline",
+		Use:     "reset",
+		Aliases: []string{"r"},
+		Short:   "Reset the currently active pipeline",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			conn, er := command_prechecks.Perform(cmd, args, roverIndex, roverdHost, roverdUsername, roverdPassword)
 			if er != nil {

--- a/roverctl/src/commands/prechecks/prechecks.go
+++ b/roverctl/src/commands/prechecks/prechecks.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/VU-ASE/rover/roverctl/src/configuration"
+	view_incompatible "github.com/VU-ASE/rover/roverctl/src/views/incompatible"
 
 	"github.com/spf13/cobra"
 )
@@ -33,5 +34,7 @@ func Perform(cmd *cobra.Command, args []string, roverIndex int, roverdHost strin
 		Username:   roverdUsername,
 		Password:   roverdPassword,
 	}
+	view_incompatible.WarnOnIncompatible(conn)
+
 	return &conn, nil
 }

--- a/roverctl/src/commands/services/build.go
+++ b/roverctl/src/commands/services/build.go
@@ -1,0 +1,67 @@
+package command_services
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	command_prechecks "github.com/VU-ASE/rover/roverctl/src/commands/prechecks"
+	"github.com/VU-ASE/rover/roverctl/src/style"
+	utils "github.com/VU-ASE/rover/roverctl/src/utils"
+)
+
+func addBuild(rootCmd *cobra.Command) {
+	// General flags
+	var roverIndex int
+	var roverdHost string
+	var roverdUsername string
+	var roverdPassword string
+
+	// services command
+	var infoCmd = &cobra.Command{
+		Use:     "build",
+		Aliases: []string{"compile", "b"},
+		Short:   "Build a service on the Rover",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 3 {
+				return fmt.Errorf("exactly one fully qualified service must be provided in the form <author> <name> <version>")
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			conn, er := command_prechecks.Perform(cmd, args, roverIndex, roverdHost, roverdUsername, roverdPassword)
+			if er != nil {
+				return er
+			}
+			api := conn.ToApiClient()
+
+			author := args[0]
+			name := args[1]
+			version := strings.TrimPrefix(args[2], "v") // should pass "1.0.0" instead of "v1.0.0"
+
+			fmt.Printf("Attempting to build service on Rover...\n")
+			service := api.ServicesAPI.ServicesAuthorServiceVersionPost(
+				context.Background(),
+				author,
+				name,
+				version,
+			)
+			http, err := service.Execute()
+			if err != nil {
+				fmt.Printf("Could not build service: %s\n", utils.ParseHTTPError(err, http))
+				return nil
+			}
+
+			fmt.Printf("Built service %s/%s (%s)\n", style.Primary.Render(author), style.Primary.Render(name), (version))
+			return nil
+		},
+	}
+	infoCmd.Flags().IntVarP(&roverIndex, "rover", "r", 0, "The index of the rover to upload to, between 1 and 20")
+	infoCmd.Flags().StringVarP(&roverdHost, "host", "", "", "The roverd endpoint to connect to (if not using --rover)")
+	infoCmd.Flags().StringVarP(&roverdUsername, "username", "u", "debix", "The username to use to connect to the roverd endpoint")
+	infoCmd.Flags().StringVarP(&roverdPassword, "password", "p", "debix", "The password to use to connect to the roverd endpoint")
+
+	rootCmd.AddCommand(infoCmd)
+}

--- a/roverctl/src/commands/services/delete.go
+++ b/roverctl/src/commands/services/delete.go
@@ -21,8 +21,9 @@ func addDelete(rootCmd *cobra.Command) {
 
 	// services command
 	var infoCmd = &cobra.Command{
-		Use:   "delete",
-		Short: "Delete a fully qualified service from the Rover",
+		Use:     "delete",
+		Aliases: []string{"d"},
+		Short:   "Delete a fully qualified service from the Rover",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 3 {
 				return fmt.Errorf("exactly one fully qualified service must be provided in the form <author> <name> <version>")

--- a/roverctl/src/commands/services/info.go
+++ b/roverctl/src/commands/services/info.go
@@ -61,7 +61,7 @@ func addInfo(rootCmd *cobra.Command) {
 			} else {
 				fmt.Printf("%s\n", ("This service was last built at ")+style.Primary.Render(time.Unix(*res.BuiltAt/1000, 0).String()))
 			}
-			fmt.Printf("Installation directory: %s\n", style.Primary.Render("/home/debix/.rover/"+author+"/"+name+"/"+version))
+			fmt.Printf("Directory on Rover: %s\n", style.Primary.Render("/home/debix/.rover/"+author+"/"+name+"/"+version))
 
 			if len(res.Configuration) > 0 {
 				fmt.Printf("%s\n", style.Gray.Render("\nConfigurable options:"))

--- a/roverctl/src/commands/services/info.go
+++ b/roverctl/src/commands/services/info.go
@@ -59,8 +59,9 @@ func addInfo(rootCmd *cobra.Command) {
 			if builtAt == nil {
 				fmt.Printf("%s\n", style.Gray.Render("This service has not been built yet"))
 			} else {
-				fmt.Printf("%s\n", style.Gray.Render("This service was last built at ")+style.Primary.Render(time.Unix(*res.BuiltAt/1000, 0).String()))
+				fmt.Printf("%s\n", ("This service was last built at ")+style.Primary.Render(time.Unix(*res.BuiltAt/1000, 0).String()))
 			}
+			fmt.Printf("Installation directory: %s\n", style.Primary.Render("/home/debix/.rover/"+author+"/"+name+"/"+version))
 
 			if len(res.Configuration) > 0 {
 				fmt.Printf("%s\n", style.Gray.Render("\nConfigurable options:"))

--- a/roverctl/src/commands/services/info.go
+++ b/roverctl/src/commands/services/info.go
@@ -1,0 +1,115 @@
+package command_services
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	command_prechecks "github.com/VU-ASE/rover/roverctl/src/commands/prechecks"
+	"github.com/VU-ASE/rover/roverctl/src/style"
+	utils "github.com/VU-ASE/rover/roverctl/src/utils"
+)
+
+func addInfo(rootCmd *cobra.Command) {
+	// General flags
+	var roverIndex int
+	var roverdHost string
+	var roverdUsername string
+	var roverdPassword string
+
+	// services command
+	var infoCmd = &cobra.Command{
+		Use:     "info",
+		Aliases: []string{"i", "describe", "about"},
+		Short:   "View info about an installed service on the Rover",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 3 {
+				return fmt.Errorf("exactly one fully qualified service must be provided in the form <author> <name> <version>")
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			conn, er := command_prechecks.Perform(cmd, args, roverIndex, roverdHost, roverdUsername, roverdPassword)
+			if er != nil {
+				return er
+			}
+			api := conn.ToApiClient()
+
+			author := args[0]
+			name := args[1]
+			version := strings.TrimPrefix(args[2], "v") // should pass "1.0.0" instead of "v1.0.0"
+
+			service := api.ServicesAPI.ServicesAuthorServiceVersionGet(
+				context.Background(),
+				author,
+				name,
+				version,
+			)
+			res, http, err := service.Execute()
+			if err != nil {
+				fmt.Printf("Could not get information about service: %s\n", utils.ParseHTTPError(err, http))
+				return nil
+			}
+
+			fmt.Printf("About %s by %s (%s)\n", style.Primary.Render(name), style.Primary.Render(author), (version))
+			builtAt := res.BuiltAt
+			if builtAt == nil {
+				fmt.Printf("%s\n", style.Gray.Render("This service has not been built yet"))
+			} else {
+				fmt.Printf("%s\n", style.Gray.Render("This service was last built at ")+style.Primary.Render(time.Unix(*res.BuiltAt/1000, 0).String()))
+			}
+
+			if len(res.Configuration) > 0 {
+				fmt.Printf("%s\n", style.Gray.Render("\nConfigurable options:"))
+				for _, c := range res.Configuration {
+					floatVal := c.Value.Float32
+					strVal := c.Value.String
+
+					prefix := ""
+					if c.Tunable {
+						prefix = style.Success.Render(" tunable")
+					}
+
+					fmt.Printf("  -%s %s %s: ", prefix, style.Gray.Render(c.Type), (c.Name))
+					if floatVal != nil {
+						// Print float value with 3 decimal places
+						fmt.Printf("%s", style.Primary.Render(fmt.Sprintf("%.3f", *floatVal)))
+					} else if strVal != nil {
+						fmt.Printf("%s", style.Primary.Render(*strVal))
+					} else {
+						fmt.Printf("%s", style.Primary.Render("null"))
+					}
+					fmt.Printf("\n")
+				}
+			}
+
+			if len(res.Inputs) > 0 {
+				fmt.Printf("%s\n", style.Gray.Render("\nInputs:"))
+				for _, i := range res.Inputs {
+					fmt.Printf("   %s:\n", (i.Service))
+					for _, s := range i.Streams {
+						fmt.Printf("      - %s\n", (s))
+					}
+				}
+			}
+
+			if len(res.Outputs) > 0 {
+				fmt.Printf("%s\n", style.Gray.Render("\nOutputs:"))
+				for _, o := range res.Outputs {
+					fmt.Printf("   - %s\n", (o))
+				}
+			}
+
+			return nil
+		},
+	}
+	infoCmd.Flags().IntVarP(&roverIndex, "rover", "r", 0, "The index of the rover to upload to, between 1 and 20")
+	infoCmd.Flags().StringVarP(&roverdHost, "host", "", "", "The roverd endpoint to connect to (if not using --rover)")
+	infoCmd.Flags().StringVarP(&roverdUsername, "username", "u", "debix", "The username to use to connect to the roverd endpoint")
+	infoCmd.Flags().StringVarP(&roverdPassword, "password", "p", "debix", "The password to use to connect to the roverd endpoint")
+
+	rootCmd.AddCommand(infoCmd)
+}

--- a/roverctl/src/commands/services/init.go
+++ b/roverctl/src/commands/services/init.go
@@ -1,4 +1,4 @@
-package command_service_init
+package command_services
 
 import (
 	"fmt"
@@ -17,14 +17,14 @@ import (
 
 var presets = []string{"go", "c", "python"}
 
-func Add(rootCmd *cobra.Command) {
+func addInit(rootCmd *cobra.Command) {
 	// General flags
 	var name string
 	var source string
 
 	// services command
 	var infoCmd = &cobra.Command{
-		Use:   "service init [" + strings.Join(presets, "|") + "]",
+		Use:   "init [" + strings.Join(presets, "|") + "]",
 		Short: "Create a new service in your current working directory, based on a template",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 2 {

--- a/roverctl/src/commands/services/install.go
+++ b/roverctl/src/commands/services/install.go
@@ -21,8 +21,9 @@ func addInstall(rootCmd *cobra.Command) {
 
 	// services command
 	var infoCmd = &cobra.Command{
-		Use:   "install",
-		Short: "Install a service from a given URL onto the Rover",
+		Use:     "install",
+		Aliases: []string{"i"},
+		Short:   "Install a service from a given URL onto the Rover",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			conn, er := command_prechecks.Perform(cmd, args, roverIndex, roverdHost, roverdUsername, roverdPassword)
 			if er != nil {

--- a/roverctl/src/commands/services/install.go
+++ b/roverctl/src/commands/services/install.go
@@ -1,0 +1,58 @@
+package command_services
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	command_prechecks "github.com/VU-ASE/rover/roverctl/src/commands/prechecks"
+	"github.com/VU-ASE/rover/roverctl/src/openapi"
+	"github.com/VU-ASE/rover/roverctl/src/style"
+	utils "github.com/VU-ASE/rover/roverctl/src/utils"
+)
+
+func addInstall(rootCmd *cobra.Command) {
+	// General flags
+	var roverIndex int
+	var roverdHost string
+	var roverdUsername string
+	var roverdPassword string
+
+	// services command
+	var infoCmd = &cobra.Command{
+		Use:   "install",
+		Short: "Install a service from a given URL onto the Rover",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			conn, er := command_prechecks.Perform(cmd, args, roverIndex, roverdHost, roverdUsername, roverdPassword)
+			if er != nil {
+				return er
+			}
+			api := conn.ToApiClient()
+			if len(args) != 1 {
+				return fmt.Errorf("Specify the ZIP URL of the service to install")
+			}
+
+			fetch := api.ServicesAPI.FetchPost(
+				context.Background(),
+			)
+			fetch = fetch.FetchPostRequest(openapi.FetchPostRequest{
+				Url: args[0],
+			})
+			res, http, err := fetch.Execute()
+			if err != nil {
+				fmt.Printf("Could not install service: %s\n", utils.ParseHTTPError(err, http))
+				return nil
+			}
+
+			fmt.Printf("Installed service %s by %s (%s)\n", style.Primary.Render(res.Fq.Name), style.Primary.Render(res.Fq.Author), (res.Fq.Version))
+			return nil
+		},
+	}
+	infoCmd.Flags().IntVarP(&roverIndex, "rover", "r", 0, "The index of the rover to upload to, between 1 and 20")
+	infoCmd.Flags().StringVarP(&roverdHost, "host", "", "", "The roverd endpoint to connect to (if not using --rover)")
+	infoCmd.Flags().StringVarP(&roverdUsername, "username", "u", "debix", "The username to use to connect to the roverd endpoint")
+	infoCmd.Flags().StringVarP(&roverdPassword, "password", "p", "debix", "The password to use to connect to the roverd endpoint")
+
+	rootCmd.AddCommand(infoCmd)
+}

--- a/roverctl/src/commands/services/install.go
+++ b/roverctl/src/commands/services/install.go
@@ -21,9 +21,8 @@ func addInstall(rootCmd *cobra.Command) {
 
 	// services command
 	var infoCmd = &cobra.Command{
-		Use:     "install",
-		Aliases: []string{"i"},
-		Short:   "Install a service from a given URL onto the Rover",
+		Use:   "install",
+		Short: "Install a service from a given URL onto the Rover",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			conn, er := command_prechecks.Perform(cmd, args, roverIndex, roverdHost, roverdUsername, roverdPassword)
 			if er != nil {
@@ -34,6 +33,7 @@ func addInstall(rootCmd *cobra.Command) {
 				return fmt.Errorf("Specify the ZIP URL of the service to install")
 			}
 
+			fmt.Printf("Attempting to install service on Rover...\n")
 			fetch := api.ServicesAPI.FetchPost(
 				context.Background(),
 			)

--- a/roverctl/src/commands/services/services.go
+++ b/roverctl/src/commands/services/services.go
@@ -19,7 +19,7 @@ func Add(rootCmd *cobra.Command) {
 	var lines int
 
 	// services command
-	var infoCmd = &cobra.Command{
+	var servicesCmd = &cobra.Command{
 		Use:   "services",
 		Short: "Fetch the currently installed services",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -49,11 +49,14 @@ func Add(rootCmd *cobra.Command) {
 			return nil
 		},
 	}
-	infoCmd.Flags().IntVarP(&roverIndex, "rover", "r", 0, "The index of the rover to upload to, between 1 and 20")
-	infoCmd.Flags().StringVarP(&roverdHost, "host", "", "", "The roverd endpoint to connect to (if not using --rover)")
-	infoCmd.Flags().StringVarP(&roverdUsername, "username", "u", "debix", "The username to use to connect to the roverd endpoint")
-	infoCmd.Flags().StringVarP(&roverdPassword, "password", "p", "debix", "The password to use to connect to the roverd endpoint")
-	infoCmd.Flags().IntVarP(&lines, "lines", "l", 50, "The number of log lines to display")
+	servicesCmd.Flags().IntVarP(&roverIndex, "rover", "r", 0, "The index of the rover to upload to, between 1 and 20")
+	servicesCmd.Flags().StringVarP(&roverdHost, "host", "", "", "The roverd endpoint to connect to (if not using --rover)")
+	servicesCmd.Flags().StringVarP(&roverdUsername, "username", "u", "debix", "The username to use to connect to the roverd endpoint")
+	servicesCmd.Flags().StringVarP(&roverdPassword, "password", "p", "debix", "The password to use to connect to the roverd endpoint")
+	servicesCmd.Flags().IntVarP(&lines, "lines", "l", 50, "The number of log lines to display")
 
-	rootCmd.AddCommand(infoCmd)
+	addInstall(servicesCmd)
+	addDelete(servicesCmd)
+
+	rootCmd.AddCommand(servicesCmd)
 }

--- a/roverctl/src/commands/services/services.go
+++ b/roverctl/src/commands/services/services.go
@@ -59,6 +59,8 @@ func Add(rootCmd *cobra.Command) {
 	addInstall(servicesCmd)
 	addDelete(servicesCmd)
 	addInit(servicesCmd)
+	addInfo(servicesCmd)
+	addBuild(servicesCmd)
 
 	rootCmd.AddCommand(servicesCmd)
 }

--- a/roverctl/src/commands/services/services.go
+++ b/roverctl/src/commands/services/services.go
@@ -20,8 +20,9 @@ func Add(rootCmd *cobra.Command) {
 
 	// services command
 	var servicesCmd = &cobra.Command{
-		Use:   "services",
-		Short: "Fetch the currently installed services",
+		Use:     "services",
+		Aliases: []string{"service", "svc", "s"},
+		Short:   "Fetch the currently installed services",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			conn, er := command_prechecks.Perform(cmd, args, roverIndex, roverdHost, roverdUsername, roverdPassword)
 			if er != nil {
@@ -57,6 +58,7 @@ func Add(rootCmd *cobra.Command) {
 
 	addInstall(servicesCmd)
 	addDelete(servicesCmd)
+	addInit(servicesCmd)
 
 	rootCmd.AddCommand(servicesCmd)
 }

--- a/roverctl/src/commands/upload/upload.go
+++ b/roverctl/src/commands/upload/upload.go
@@ -22,8 +22,9 @@ func Add(rootCmd *cobra.Command) {
 	// Upload command
 	var watch bool
 	var uploadCmd = &cobra.Command{
-		Use:   "upload <PATHS>",
-		Short: "Upload specified service folders to a Rover",
+		Use:     "upload <PATHS>",
+		Aliases: []string{"u", "sync"},
+		Short:   "Upload specified service folders to a Rover",
 		Long: `The upload command allows you to upload one or more service folders to the Rover. 
 You can optionally specify the --watch flag to enable file watch and upload.`,
 		Args: func(cmd *cobra.Command, args []string) error {

--- a/roverctl/src/main.go
+++ b/roverctl/src/main.go
@@ -13,7 +13,6 @@ import (
 	command_info "github.com/VU-ASE/rover/roverctl/src/commands/info"
 	command_logs "github.com/VU-ASE/rover/roverctl/src/commands/logs"
 	command_pipeline "github.com/VU-ASE/rover/roverctl/src/commands/pipeline"
-	command_service_init "github.com/VU-ASE/rover/roverctl/src/commands/service_init"
 	command_services "github.com/VU-ASE/rover/roverctl/src/commands/services"
 
 	command_ssh "github.com/VU-ASE/rover/roverctl/src/commands/ssh"
@@ -37,7 +36,6 @@ func run() error {
 	rootCmd := commands.NewRoot()
 	command_pipeline.Add(rootCmd)
 	command_services.Add(rootCmd)
-	command_service_init.Add(rootCmd)
 	command_upload.Add(rootCmd)
 	command_logs.Add(rootCmd)
 	command_ssh.Add(rootCmd)

--- a/roverctl/src/main.go
+++ b/roverctl/src/main.go
@@ -11,7 +11,6 @@ import (
 	command_author "github.com/VU-ASE/rover/roverctl/src/commands/author"
 	command_calibrate "github.com/VU-ASE/rover/roverctl/src/commands/calibrate"
 	command_info "github.com/VU-ASE/rover/roverctl/src/commands/info"
-	command_install "github.com/VU-ASE/rover/roverctl/src/commands/install"
 	command_logs "github.com/VU-ASE/rover/roverctl/src/commands/logs"
 	command_pipeline "github.com/VU-ASE/rover/roverctl/src/commands/pipeline"
 	command_service_init "github.com/VU-ASE/rover/roverctl/src/commands/service_init"
@@ -46,7 +45,6 @@ func run() error {
 	command_author.Add(rootCmd)
 	command_update.Add(rootCmd)
 	command_calibrate.Add(rootCmd)
-	command_install.Add(rootCmd)
 
 	err = rootCmd.Execute()
 	if err != nil {

--- a/roverctl/src/utils/http.go
+++ b/roverctl/src/utils/http.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/VU-ASE/rover/roverctl/src/openapi"
+	"github.com/VU-ASE/rover/roverctl/src/style"
 )
 
 func ParseHTTPError(err error, htt *http.Response) error {
@@ -42,7 +43,7 @@ func ParseHTTPError(err error, htt *http.Response) error {
 			unescaped := strings.ReplaceAll(content, `\n`, "\n")
 			unescaped = strings.ReplaceAll(unescaped, `\"`, "\"")
 
-			return fmt.Errorf("%s", unescaped)
+			return fmt.Errorf("%s", style.Error.Render(unescaped))
 		}
 	} else {
 		return fmt.Errorf("Operation failed: %v", err)

--- a/roverctl/src/views/incompatible/incompatible.go
+++ b/roverctl/src/views/incompatible/incompatible.go
@@ -1,0 +1,28 @@
+package view_incompatible
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/VU-ASE/rover/roverctl/src/configuration"
+	"github.com/VU-ASE/rover/roverctl/src/style"
+	"github.com/VU-ASE/rover/roverctl/src/utils"
+	view_info "github.com/VU-ASE/rover/roverctl/src/views/info"
+)
+
+// Best effort try to warn that roverctl and roverd are incompatible
+func WarnOnIncompatible(conn configuration.RoverConnection) {
+	// Try to query info
+	info := conn.ToApiClient().HealthAPI.StatusGet(
+		context.Background(),
+	)
+	res, _, err := info.Execute()
+	if err != nil {
+		return
+	}
+
+	// Check if the versions are compatible
+	if !utils.VersionsEqual(res.Version, view_info.Version) {
+		fmt.Printf("%s roverctl (%s) and roverd (%s) have incompatible installations. Run %s to resolve.\n", style.Warning.Bold(true).Render("Warning!"), utils.Version(view_info.Version), utils.Version(res.Version), style.Primary.Render("roverctl update"))
+	}
+}

--- a/roverctl/src/views/info/info.go
+++ b/roverctl/src/views/info/info.go
@@ -74,9 +74,14 @@ func (m model) View() string {
 _______________(__)_____________(__)_________________`)
 	s += "\n\nPowered by the " + style.Bold.Render("Vrije Universiteit Amsterdam ASE-Team") + ".\nFind more information at " + style.Primary.Render("ase.vu.nl") + "\n"
 
+	author := state.Get().Config.Author
+	if author == "" {
+		author = style.Warning.Render("not set")
+	}
+
 	s += "\n" + style.Title.Render("Roverctl") + "\n"
 	s += style.Gray.Render("Build version: ") + Version + "\n"
-	s += style.Gray.Render("Author: ") + state.Get().Config.Author + "\n"
+	s += style.Gray.Render("Author: ") + author + "\n"
 	s += style.Gray.Render("Configuration location: ") + configuration.LocalConfigDir() + "\n"
 	s += style.Gray.Render("Architecture: ") + runtime.GOOS + "/" + runtime.GOARCH + "\n"
 

--- a/roverctl/src/views/upload/upload.go
+++ b/roverctl/src/views/upload/upload.go
@@ -195,7 +195,7 @@ func (m model) View() string {
 
 		if !ok {
 			s += (pathStr) + " -> " + m.rover.Identifier + style.Gray.Render(" (unknown)") + "\n"
-			s += style.Warning.Render("✗ Not a valid service directory") + "\n\n"
+			s += style.Warning.Render("✗ No valid service.yaml file found in this directory") + "\n" + style.Gray.Render("Check out ") + style.Primary.Render("https://ase.vu.nl/docs/tutorials/Fundamental%20Concepts/services") + style.Gray.Render(" to understand service.yaml requirements") + "\n\n"
 			continue
 		}
 		s += (pathStr) + " -> " + (m.rover.Identifier + style.Gray.Render(" (/home/debix/.rover/"+st.Config.Author+"/"+info.Name+"/"+info.Version+")")) + "\n"


### PR DESCRIPTION
This PR introduces new commands (`service build`, `service info`), shorthands (`svc` for `services`, `pl` for `pipeline`, etc.) and improvements to error reporting with `roverctl`. The install script now also adds `rover` as an alias for `roverctl` to make it just a bit more ergonomic.