### PR TITLE
Shutdown and emergency commands

### DIFF
--- a/roverctl/install.sh
+++ b/roverctl/install.sh
@@ -87,12 +87,12 @@ if ! command -v roverctl &> /dev/null; then
   echo "Added ${INSTALL_DIR} to PATH in $shell_profile. Please restart your shell or run 'source $shell_profile'."
 fi
 
-# Add alias for rover
-shell_profile=$(detect_shell_profile)
-if ! grep -q "alias rover=" "$shell_profile"; then
-  echo "Adding alias 'rover' for 'roverctl'..."
-  echo "alias rover='roverctl'" >> "$shell_profile"
-  echo "Alias added to $shell_profile. Please restart your shell or run 'source $shell_profile'."
+# Create symlink for rover
+if [ ! -L "${INSTALL_DIR}/rover" ]; then
+  echo "Creating symlink 'rover' -> 'roverctl'..."
+  sudo ln -s "${INSTALL_DIR}/roverctl" "${INSTALL_DIR}/rover"
+else
+  echo "Symlink '${INSTALL_DIR}/rover' already exists."
 fi
 
-echo "Installation complete! Run 'roverctl' to get started."
+echo "Installation complete! Run 'roverctl' (or shorthand 'rover') to get started."

--- a/roverctl/livereload.sh
+++ b/roverctl/livereload.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-# based on https://leg100.github.io/en/posts/building-bubbletea-programs/#3-live-reload-code-changes
-
-# watch code changes, trigger re-build, and kill process 
-while true; do
-    make build && pkill -f 'bin/roverctl'
-    inotifywait -e attrib $(find . -name '*.go') || exit
-done

--- a/roverctl/preview.sh
+++ b/roverctl/preview.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-# based on https://leg100.github.io/en/posts/building-bubbletea-programs/#3-live-reload-code-changes
-
-# in foreground, continously run app
-while true; do
-    ./bin/roverctl
-done

--- a/roverctl/src/commands/emergency/emergency.go
+++ b/roverctl/src/commands/emergency/emergency.go
@@ -1,0 +1,51 @@
+package command_emergency
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	command_prechecks "github.com/VU-ASE/rover/roverctl/src/commands/prechecks"
+	utils "github.com/VU-ASE/rover/roverctl/src/utils"
+)
+
+func Add(rootCmd *cobra.Command) {
+	// General flags
+	var roverIndex int
+	var roverdHost string
+	var roverdUsername string
+	var roverdPassword string
+
+	// services command
+	var infoCmd = &cobra.Command{
+		Use:     "emergency",
+		Aliases: []string{"e", "em", "panic", "reset"},
+		Short:   "Stop any running pipeline and reset the Rover",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			conn, er := command_prechecks.Perform(cmd, args, roverIndex, roverdHost, roverdUsername, roverdPassword)
+			if er != nil {
+				return er
+			}
+			api := conn.ToApiClient()
+
+			emergency := api.HealthAPI.EmergencyPost(
+				context.Background(),
+			)
+			http, err := emergency.Execute()
+			if err != nil {
+				fmt.Printf("Could not run emergency command: %s\n", utils.ParseHTTPError(err, http))
+				return nil
+			}
+
+			fmt.Printf("Emergency reset successful\n")
+			return nil
+		},
+	}
+	infoCmd.Flags().IntVarP(&roverIndex, "rover", "r", 0, "The index of the rover to upload to, between 1 and 20")
+	infoCmd.Flags().StringVarP(&roverdHost, "host", "", "", "The roverd endpoint to connect to (if not using --rover)")
+	infoCmd.Flags().StringVarP(&roverdUsername, "username", "u", "debix", "The username to use to connect to the roverd endpoint")
+	infoCmd.Flags().StringVarP(&roverdPassword, "password", "p", "debix", "The password to use to connect to the roverd endpoint")
+
+	rootCmd.AddCommand(infoCmd)
+}

--- a/roverctl/src/commands/shutdown/shutdown.go
+++ b/roverctl/src/commands/shutdown/shutdown.go
@@ -1,0 +1,53 @@
+package command_shutdown
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	command_prechecks "github.com/VU-ASE/rover/roverctl/src/commands/prechecks"
+	"github.com/VU-ASE/rover/roverctl/src/style"
+	utils "github.com/VU-ASE/rover/roverctl/src/utils"
+)
+
+func Add(rootCmd *cobra.Command) {
+	// General flags
+	var roverIndex int
+	var roverdHost string
+	var roverdUsername string
+	var roverdPassword string
+
+	// services command
+	var infoCmd = &cobra.Command{
+		Use:     "shutdown",
+		Aliases: []string{"sd"},
+		Short:   "Shut down the Debix immediately",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			conn, er := command_prechecks.Perform(cmd, args, roverIndex, roverdHost, roverdUsername, roverdPassword)
+			if er != nil {
+				return er
+			}
+			api := conn.ToApiClient()
+
+			shutdown := api.HealthAPI.ShutdownPost(
+				context.Background(),
+			)
+			http, err := shutdown.Execute()
+			if err != nil {
+				fmt.Printf("Could not shut down: %s\n", utils.ParseHTTPError(err, http))
+				return nil
+			}
+
+			fmt.Printf("Rover was successfully shut down\n")
+			fmt.Printf("%s.\n", style.Warning.Render("When you see the unplug symbol, unplug power immediately"))
+			return nil
+		},
+	}
+	infoCmd.Flags().IntVarP(&roverIndex, "rover", "r", 0, "The index of the rover to upload to, between 1 and 20")
+	infoCmd.Flags().StringVarP(&roverdHost, "host", "", "", "The roverd endpoint to connect to (if not using --rover)")
+	infoCmd.Flags().StringVarP(&roverdUsername, "username", "u", "debix", "The username to use to connect to the roverd endpoint")
+	infoCmd.Flags().StringVarP(&roverdPassword, "password", "p", "debix", "The password to use to connect to the roverd endpoint")
+
+	rootCmd.AddCommand(infoCmd)
+}

--- a/roverctl/src/main.go
+++ b/roverctl/src/main.go
@@ -10,10 +10,12 @@ import (
 	commands "github.com/VU-ASE/rover/roverctl/src/commands"
 	command_author "github.com/VU-ASE/rover/roverctl/src/commands/author"
 	command_calibrate "github.com/VU-ASE/rover/roverctl/src/commands/calibrate"
+	command_emergency "github.com/VU-ASE/rover/roverctl/src/commands/emergency"
 	command_info "github.com/VU-ASE/rover/roverctl/src/commands/info"
 	command_logs "github.com/VU-ASE/rover/roverctl/src/commands/logs"
 	command_pipeline "github.com/VU-ASE/rover/roverctl/src/commands/pipeline"
 	command_services "github.com/VU-ASE/rover/roverctl/src/commands/services"
+	command_shutdown "github.com/VU-ASE/rover/roverctl/src/commands/shutdown"
 
 	command_ssh "github.com/VU-ASE/rover/roverctl/src/commands/ssh"
 	command_update "github.com/VU-ASE/rover/roverctl/src/commands/update"
@@ -43,6 +45,8 @@ func run() error {
 	command_author.Add(rootCmd)
 	command_update.Add(rootCmd)
 	command_calibrate.Add(rootCmd)
+	command_shutdown.Add(rootCmd)
+	command_emergency.Add(rootCmd)
 
 	err = rootCmd.Execute()
 	if err != nil {


### PR DESCRIPTION
Introduces `roverctl emergency`, `roverctl shutdown` and useful aliasses, as well as creating a symlink to map `rover` to `roverctl`