### PR TITLE
Changed the required field to incldue "name", "version"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,4 @@ bin
 # :/
 .DS_Store
 
-# We don't want to include the spec as it should be stored in single source of truth Roverd, not in this repo
-spec
-
 manage/safe-controller

--- a/spec/service-boot/example.json
+++ b/spec/service-boot/example.json
@@ -1,6 +1,6 @@
 {
     "name": "my-controller",
-    "as": "controller"
+    "as": "controller",
     "version": "1.0.1",
     "inputs": [{
             "service": "imaging",

--- a/spec/service-boot/schema.json
+++ b/spec/service-boot/schema.json
@@ -133,7 +133,8 @@
         }
     },
     "required": [
-        "service",
+        "name",
+        "version",
         "inputs",
         "outputs",
         "configuration",


### PR DESCRIPTION
The field "service" was required for the bootspec but due to nesting that was indeed wrong. Now that has been changed to include "name" and "version" instead